### PR TITLE
Fix RLDLT to live in the conex namespace

### DIFF
--- a/conex/RLDLT.h
+++ b/conex/RLDLT.h
@@ -1,6 +1,6 @@
-#include "conex/debug_macros.h"
-#include <Eigen/Dense>
-// This file is part of Eigen, a lightweight C++ template library
+#pragma once
+
+// This file was copied from Eigen, a lightweight C++ template library
 // for linear algebra.
 //
 // Copyright (C) 2008-2011 Gael Guennebaud <gael.guennebaud@inria.fr>
@@ -12,19 +12,20 @@
 // Public License v. 2.0. If a copy of the MPL was not distributed
 // with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#ifndef EIGEN_RLDLT_H
-#define EIGEN_RLDLT_H
+#include <Eigen/Dense>
 
-namespace Eigen {
+#include "conex/debug_macros.h"
 
-namespace internal {
+namespace conex {
+namespace eigen_stuff {
+
+using namespace Eigen;
+namespace internal = Eigen::internal;
+
+namespace detail {
 template <typename MatrixType, int UpLo>
 struct RLDLT_Traits;
-
-// PositiveSemiDef means positive semi-definite and non-zero; same for
-// NegativeSemiDef
-// enum SignMatrix { PositiveSemiDef, NegativeSemiDef, ZeroSign, Indefinite };
-}  // namespace internal
+}  // namespace detail
 
 /** \ingroup Cholesky_Module
  *
@@ -78,7 +79,7 @@ class RLDLT {
   typedef PermutationMatrix<RowsAtCompileTime, MaxRowsAtCompileTime>
       PermutationType;
 
-  typedef internal::LDLT_Traits<MatrixType, UpLo> Traits;
+  typedef detail::RLDLT_Traits<MatrixType, UpLo> Traits;
 
   /** \brief Default Constructor.
    *
@@ -289,7 +290,9 @@ class RLDLT {
   ComputationInfo m_info;
 };
 
-namespace internal {
+namespace detail {
+
+using namespace Eigen::internal;
 
 template <int UpLo>
 struct rldlt_inplace;
@@ -564,7 +567,7 @@ RLDLT<MatrixType, _UpLo>& RLDLT<MatrixType, _UpLo>::compute(
   m_temporary.resize(size);
   m_sign = internal::ZeroSign;
 
-  m_regularization_used = !internal::rldlt_inplace<UpLo>::unblocked(
+  m_regularization_used = !detail::rldlt_inplace<UpLo>::unblocked(
       m_matrix, m_transpositions, m_temporary, m_sign);
 
   m_info = Success;
@@ -598,7 +601,7 @@ RLDLT<MatrixType, _UpLo>& RLDLT<MatrixType, _UpLo>::rankUpdate(
     m_isInitialized = true;
   }
 
-  internal::rldlt_inplace<UpLo>::update(m_matrix, m_transpositions, m_temporary,
+  detail::rldlt_inplace<UpLo>::update(m_matrix, m_transpositions, m_temporary,
                                         w, sigma);
 
   return *this;
@@ -696,6 +699,5 @@ MatrixType RLDLT<MatrixType, _UpLo>::reconstructedMatrix() const {
   return res;
 }
 
-}  // end namespace Eigen
-
-#endif  // EIGEN_RLDLT_H
+}  // namespace eigen_stuff
+}  // namespace conex

--- a/conex/block_triangular_operations.cc
+++ b/conex/block_triangular_operations.cc
@@ -221,7 +221,7 @@ bool T::BlockCholeskyInPlace(TriangularMatrixWorkspace* C) {
 // Apply inv(M^T)  = inv(L^T P) = P^T inv(L^T)
 void T::ApplyBlockInverseOfMTranspose(
     const TriangularMatrixWorkspace& mat,
-    const std::vector<Eigen::RLDLT<Eigen::Ref<MatrixXd>>> factorization,
+    const std::vector<eigen_stuff::RLDLT<Eigen::Ref<MatrixXd>>> factorization,
     VectorXd* y) {
   PartitionVectorIterator ypart(*y, mat.N, mat.supernode_size);
   // mat.diagonal.back().triangularView<Eigen::Lower>().transpose().solveInPlace(ypart.b_i());
@@ -264,7 +264,7 @@ void T::ApplyBlockInverseOfMTranspose(
 
 void T::ApplyBlockInverseOfMD(
     const TriangularMatrixWorkspace& mat,
-    const std::vector<Eigen::RLDLT<Eigen::Ref<MatrixXd>>> factorization,
+    const std::vector<eigen_stuff::RLDLT<Eigen::Ref<MatrixXd>>> factorization,
     VectorXd* y) {
   // Apply inv(M) = inv(P^T L) = inv(L) P
   PartitionVectorForwardIterator ypart(*y, mat.supernode_size);
@@ -314,7 +314,7 @@ void T::ApplyBlockInverseOfMD(
 //          = inv(D_1) inv(L) P  * off_diag
 bool T::BlockLDLTInPlace(
     TriangularMatrixWorkspace* C,
-    std::vector<Eigen::RLDLT<Eigen::Ref<MatrixXd>>>* factorization) {
+    std::vector<eigen_stuff::RLDLT<Eigen::Ref<MatrixXd>>>* factorization) {
   auto& llts = *factorization;
   llts.clear();
 

--- a/conex/block_triangular_operations.h
+++ b/conex/block_triangular_operations.h
@@ -14,22 +14,22 @@ struct BlockTriangularOperations {
   static bool BlockCholeskyInPlace(TriangularMatrixWorkspace* mat);
   static bool BlockLDLTInPlace(
       TriangularMatrixWorkspace* mat,
-      std::vector<Eigen::RLDLT<Eigen::Ref<Eigen::MatrixXd>>>* factorization);
+      std::vector<eigen_stuff::RLDLT<Eigen::Ref<Eigen::MatrixXd>>>* factorization);
   static void ApplyBlockInverseOfMTranspose(
       const TriangularMatrixWorkspace& mat,
-      const std::vector<Eigen::RLDLT<Eigen::Ref<Eigen::MatrixXd>>>
+      const std::vector<eigen_stuff::RLDLT<Eigen::Ref<Eigen::MatrixXd>>>
           factorization,
       Eigen::VectorXd* y);
 
   static void ApplyBlockInverseOfMD(
       const TriangularMatrixWorkspace& mat,
-      const std::vector<Eigen::RLDLT<Eigen::Ref<Eigen::MatrixXd>>>
+      const std::vector<eigen_stuff::RLDLT<Eigen::Ref<Eigen::MatrixXd>>>
           factorization,
       Eigen::VectorXd* y);
 
   static void SolveInPlaceLDLT(
       const TriangularMatrixWorkspace& mat,
-      const std::vector<Eigen::RLDLT<Eigen::Ref<Eigen::MatrixXd>>>
+      const std::vector<eigen_stuff::RLDLT<Eigen::Ref<Eigen::MatrixXd>>>
           factorization,
       Eigen::VectorXd* y) {
     ApplyBlockInverseOfMD(mat, factorization, y);

--- a/conex/kkt_solver.h
+++ b/conex/kkt_solver.h
@@ -53,7 +53,7 @@ class SupernodalKKTSolver {
   const std::vector<std::vector<int>> dual_variables_;
   MatrixData data;
   SparseTriangularMatrix mat;
-  std::vector<Eigen::RLDLT<Eigen::Ref<Eigen::MatrixXd>>> factorization;
+  std::vector<eigen_stuff::RLDLT<Eigen::Ref<Eigen::MatrixXd>>> factorization;
   Eigen::PermutationMatrix<-1> Pt;
   mutable Eigen::VectorXd b_permuted_;
   std::vector<SupernodalAssemblerBase*> assembler;

--- a/conex/test/block_triangular_operations_test.cc
+++ b/conex/test/block_triangular_operations_test.cc
@@ -202,7 +202,7 @@ void DoLDLTTest(bool diagonal, const std::vector<Clique>& cliques) {
 
   Eigen::MatrixXd X = T::ToDense(mat).selfadjointView<Eigen::Lower>();
 
-  std::vector<Eigen::RLDLT<Eigen::Ref<MatrixXd>>> factorization;
+  std::vector<eigen_stuff::RLDLT<Eigen::Ref<MatrixXd>>> factorization;
   B::BlockLDLTInPlace(&mat.workspace_, &factorization);
 
   Eigen::VectorXd z = Eigen::VectorXd::Random(X.cols());


### PR DESCRIPTION
Projects must not define classes in another project's namespace. When we fork code from another project, we need to switch it to our own namespace.